### PR TITLE
Header parsing fix and better cookie handling

### DIFF
--- a/luajit-request/init.lua
+++ b/luajit-request/init.lua
@@ -300,7 +300,7 @@ request = {
 
 				parsed_headers = {}
 
-				for key, value in headers:gmatch("\n([^:]+):%s*([^\r\n]*)") do
+				for key, value in headers:gmatch("\n([^:]+): *([^\r\n]*)") do
 					parsed_headers[key] = value
 				end
 			end


### PR DESCRIPTION
Now correctly parses empty headers (because servers are weird) and uses curl's inbuilt cookie engine.
The cookie engine deals with cookies set during redirects, and is also better at parsing the cookies. Additionally, I've exposed access to a netscape cookie file-formatted list of cookies.
